### PR TITLE
Fix timestamp rounding bug

### DIFF
--- a/youtube_transcript_api/formatters.py
+++ b/youtube_transcript_api/formatters.py
@@ -124,7 +124,16 @@ class _TextBasedFormatter(TextFormatter):
         hours_float, remainder = divmod(time, 3600)
         mins_float, secs_float = divmod(remainder, 60)
         hours, mins, secs = int(hours_float), int(mins_float), int(secs_float)
-        ms = int(round((time - int(time)) * 1000, 2))
+        ms = int(round((time - int(time)) * 1000))
+        if ms == 1000:
+            secs += 1
+            ms = 0
+            if secs == 60:
+                mins += 1
+                secs = 0
+                if mins == 60:
+                    hours += 1
+                    mins = 0
         return self._format_timestamp(hours, mins, secs, ms)
 
     def format_transcript(self, transcript: FetchedTranscript, **kwargs) -> str:

--- a/youtube_transcript_api/test/test_formatters.py
+++ b/youtube_transcript_api/test/test_formatters.py
@@ -157,3 +157,14 @@ class TestFormatters(TestCase):
     def test_formatter_loader__unknown_format(self):
         with self.assertRaises(FormatterLoader.UnknownFormatterType):
             FormatterLoader().load("png")
+
+    def test_seconds_to_timestamp_rounding(self):
+        formatter = SRTFormatter()
+        self.assertEqual(
+            formatter._seconds_to_timestamp(0.9999),
+            "00:00:01,000",
+        )
+        self.assertEqual(
+            formatter._seconds_to_timestamp(59.9999),
+            "00:01:00,000",
+        )


### PR DESCRIPTION
## Summary
- fix rounding logic when formatting timestamps
- add regression tests for timestamp rounding

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68483fbe7eb0832292e3729147051e15