### PR TITLE
Add fallback regex for captions parsing

### DIFF
--- a/youtube_transcript_api/_transcripts.py
+++ b/youtube_transcript_api/_transcripts.py
@@ -374,6 +374,18 @@ class TranscriptListFetcher:
         except YouTubeDataUnparsable as e:
             if 'class="g-recaptcha"' in html:
                 raise IpBlocked(video_id)
+            match = re.search(r"ytInitialPlayerResponse\s*=\s*(\{.*?\});", html)
+            if match:
+                try:
+                    alt_data = json.loads(match.group(1))
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    captions_json = (
+                        alt_data.get("captions", {}).get("playerCaptionsTracklistRenderer")
+                    )
+                    if captions_json and "captionTracks" in captions_json:
+                        return captions_json
             # This should never happen!
             raise e  # pragma: no cover
 

--- a/youtube_transcript_api/test/assets/youtube_no_var_player_response.html.static
+++ b/youtube_transcript_api/test/assets/youtube_no_var_player_response.html.static
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+window.ytInitialPlayerResponse={"playabilityStatus":{"status":"OK"},"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://www.youtube.com/api/timedtext?v=GJLlxj_dtq8","languageCode":"en","name":{"simpleText":"English"}}]}}};
+</script>
+</body>
+</html>

--- a/youtube_transcript_api/test/test_api.py
+++ b/youtube_transcript_api/test/test_api.py
@@ -118,6 +118,20 @@ class TestYouTubeTranscriptApi(TestCase):
             self.ref_transcript,
         )
 
+    def test_fetch__regex_fallback(self):
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://www.youtube.com/watch",
+            body=load_asset("youtube_no_var_player_response.html.static"),
+        )
+
+        transcript = YouTubeTranscriptApi().fetch("GJLlxj_dtq8")
+
+        self.assertEqual(
+            transcript,
+            self.ref_transcript,
+        )
+
     def test_list(self):
         transcript_list = YouTubeTranscriptApi().list("GJLlxj_dtq8")
 


### PR DESCRIPTION
## Summary
- handle missing `var ytInitialPlayerResponse` by falling back to regex parsing
- add test case for fallback

## Testing
- `env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484c6de4348322a54dfedf3ed50725