### PR TITLE
Add example script for quick transcript tests

### DIFF
--- a/example_test.py
+++ b/example_test.py
@@ -1,17 +1,27 @@
-import sys
+import argparse
+
 from youtube_transcript_api import YouTubeTranscriptApi
 
 
-def main(video_id: str) -> None:
+def main(video_id: str, languages: list[str]) -> None:
     """Simple script to fetch and display a transcript."""
     ytt_api = YouTubeTranscriptApi()
-    transcript = ytt_api.fetch(video_id)
+    transcript = ytt_api.fetch(video_id, languages)
     for snippet in transcript:
         print(f"{snippet.start:.2f}\t{snippet.duration:.2f}\t{snippet.text}")
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python example_test.py <video_id>")
-        sys.exit(1)
-    main(sys.argv[1])
+    parser = argparse.ArgumentParser(
+        description="Fetch a video's transcript using youtube-transcript-api"
+    )
+    parser.add_argument("video_id", help="YouTube video ID")
+    parser.add_argument(
+        "-l",
+        "--languages",
+        nargs="*",
+        default=["en"],
+        help="Preferred language codes (e.g. 'en', 'pt').",
+    )
+    args = parser.parse_args()
+    main(args.video_id, args.languages)

--- a/example_test.py
+++ b/example_test.py
@@ -1,0 +1,17 @@
+import sys
+from youtube_transcript_api import YouTubeTranscriptApi
+
+
+def main(video_id: str) -> None:
+    """Simple script to fetch and display a transcript."""
+    ytt_api = YouTubeTranscriptApi()
+    transcript = ytt_api.fetch(video_id)
+    for snippet in transcript:
+        print(f"{snippet.start:.2f}\t{snippet.duration:.2f}\t{snippet.text}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python example_test.py <video_id>")
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `example_test.py` demonstrating how to fetch a transcript using the library

## Testing
- `ruff format example_test.py`
- `ruff check example_test.py`
- `env -u HTTP_PROXY -u http_proxy -u HTTPS_PROXY -u https_proxy -u ALL_PROXY -u all_proxy -u NO_PROXY -u no_proxy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684868b2d18083228cd9fc86f411765a